### PR TITLE
fix uglifyJS doesn't support ES6

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function scope (css, parent) {
 	css = replace(css, parent + ' $1$2');
 
 	//regexp.escape
-	let parentRe = parent.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+	var parentRe = parent.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 
 	//replace self-selectors
 	css = css.replace(new RegExp('(' + parentRe + ')\\s*\\1(?=[\\s\\r\\n,{])', 'g'), '$1');


### PR DESCRIPTION
Avoid using `let` keyword or use a transpiler :|

most of compilers will throw an error:
Im facing this one with `webpack -p`

ERROR in app.js from UglifyJs
Unexpected token: name (parentRe) [./node_modules/scope-css/index.js:12,0][app.js:xxxx]

Hope it helps